### PR TITLE
Add SuperPlane branding to about page

### DIFF
--- a/src/views/about.ejs
+++ b/src/views/about.ejs
@@ -8,6 +8,7 @@
   <body>
     <h1>About StoreJS</h1>
     <p>StoreJS is a simple product catalog demo application.</p>
+    <p><strong>🛩️ Deployed via SuperPlane Ephemeral Environments</strong></p>
     <p><a href="/products">Back to products</a></p>
   </body>
 </html>


### PR DESCRIPTION
Adds a SuperPlane attribution line to the about page.

This is a demo PR to showcase ephemeral preview environments.