### PR TITLE
Test: broken deploy (API crashes on start)

### DIFF
--- a/services/api/src/app.js
+++ b/services/api/src/app.js
@@ -12,7 +12,7 @@ function findProduct(id) {
 }
 
 app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', service: 'api', timestamp: new Date().toISOString() });
+  process.exit(1); res.json({ status: 'ok', service: 'api', timestamp: new Date().toISOString() });
 });
 
 app.get('/api/products', (req, res) => {

--- a/services/web/src/server.js
+++ b/services/web/src/server.js
@@ -1,7 +1,2 @@
-const app = require('./app');
-
-const port = process.env.PORT || 3000;
-
-app.listen(port, () => {
-  console.log(`Web service listening on port ${port}`);
-});
+// Intentionally broken - crashes immediately
+throw new Error('Intentional crash for testing');


### PR DESCRIPTION
API calls process.exit(1) on health endpoint. Should fail health check and trigger cleanup.