### PR TITLE
feat: Add deployment setup for SuperPlane canvas

### DIFF
--- a/.superplane/deploy.md
+++ b/.superplane/deploy.md
@@ -1,0 +1,51 @@
+# Deployment
+
+## How it works
+
+StoreJS runs on a DigitalOcean droplet as a systemd service.
+
+- **Host:** `storejs-prod` droplet (IP may change on recreation)
+- **Service:** `storejs.service` (auto-restarts on crash, starts on boot)
+- **App directory:** `/opt/storejs`
+- **Deploy script:** `scripts/deploy.sh` (git pull, npm install, restart, health check)
+
+## Deploying
+
+SSH into the droplet and run the deploy script:
+
+```bash
+ssh -i <key> root@<droplet-ip> "bash /opt/storejs/scripts/deploy.sh"
+```
+
+Exit code 0 = success, non-zero = failure.
+
+## SuperPlane Canvas
+
+To set up a deploy-on-push workflow in SuperPlane:
+
+### Secrets needed
+
+| Secret name | Key | Description |
+|---|---|---|
+| `STOREJS_SSH_DO` | `private_key` | SSH private key for the droplet |
+
+### Canvas structure
+
+```
+github.onPush (main branch) → SSH → deploy script → success/failure
+```
+
+### Node config
+
+**Trigger:** GitHub `onPush` integration, filtered to `main` branch
+
+**SSH Action:**
+- Host: `64.225.2.53`
+- User: `root`
+- Private key: `{{ secrets.STOREJS_SSH_DO.private_key }}`
+- Command: `bash /opt/storejs/scripts/deploy.sh`
+
+### Output channels
+
+- `success` — deploy script exited 0, health check passed
+- `failure` — deploy script exited non-zero (install failed, health check failed, etc.)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+cd /opt/storejs
+
+echo "Pulling latest changes..."
+git pull origin main
+
+echo "Installing dependencies..."
+npm install --production
+
+echo "Restarting service..."
+systemctl restart storejs
+
+echo "Waiting for startup..."
+sleep 3
+
+# Health check
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/products)
+if [ "$HTTP_STATUS" = "200" ]; then
+  echo "Deploy successful - storejs is healthy (HTTP $HTTP_STATUS)"
+  exit 0
+else
+  echo "Deploy FAILED - health check returned HTTP $HTTP_STATUS"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds deploy infrastructure so any agent (Cursor, etc.) can easily create a SuperPlane deployment canvas.

## Changes

- `scripts/deploy.sh` — deploy script (git pull, npm install, restart systemd, health check)
- `.superplane/deploy.md` — documents the deployment setup + provides canvas spec for agents

## How an agent uses this

1. Read `.superplane/deploy.md`
2. Create a canvas with: `github.onPush` → SSH action → `bash /opt/storejs/scripts/deploy.sh`
3. Wire the `STOREJS_SSH_DO` secret
4. Done

## Droplet setup

- systemd service `storejs.service` is configured (auto-restart, starts on boot)
- Deploy script has built-in health check (exit 0 = success, non-zero = failure)