### PR TITLE
Rebrand puppies to cats across app

### DIFF
--- a/.superplane/deploy-prod-on-main.yaml
+++ b/.superplane/deploy-prod-on-main.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Canvas
+metadata:
+  name: storejs-deploy-on-main
+  description: Auto-deploys storejs to the DigitalOcean prod droplet whenever main changes.
+spec:
+  nodes:
+    - id: trigger-main-push
+      name: GitHub Push (main)
+      type: TYPE_TRIGGER
+      component: github.onPush
+      integration: { id: 51a76317-1481-467b-b761-3bb11af1851e, name: "" }
+      configuration:
+        repository: storejs
+        refs:
+          - { type: equals, value: refs/heads/main }
+      position: { x: 120, y: 100 }
+
+    - id: get-prod-droplet
+      name: Get Prod Droplet
+      type: TYPE_ACTION
+      component: digitalocean.getDroplet
+      integration: { id: 505ed7fc-cc70-4226-8ff6-50e3ef601b8d, name: "" }
+      configuration:
+        droplet: "575470632"
+      position: { x: 720, y: 100 }
+
+    - id: deploy-over-ssh
+      name: Deploy to Prod Droplet
+      type: TYPE_ACTION
+      component: ssh
+      configuration:
+        host: '{{ filter($["Get Prod Droplet"].data.networks.v4, .type == "public")[0].ip_address }}'
+        port: 22
+        username: root
+        authentication:
+          authMethod: ssh_key
+          privateKey: { secret: STOREJS_SSH_DO, key: private_key }
+        environment:
+          - { name: DEPLOY_SHA, value: '{{ root().data.after }}' }
+        commands: |
+          cd /opt/storejs
+          git fetch origin main
+          git checkout "$DEPLOY_SHA" -- scripts/deploy.sh
+          bash scripts/deploy.sh "$DEPLOY_SHA"
+        timeout: 300
+        connectionRetry: { enabled: true, retries: 5, intervalSeconds: 15 }
+      position: { x: 1320, y: 100 }
+
+  edges:
+    - { sourceId: trigger-main-push, targetId: get-prod-droplet, channel: default }
+    - { sourceId: get-prod-droplet, targetId: deploy-over-ssh, channel: default }

--- a/.superplane/deploy.md
+++ b/.superplane/deploy.md
@@ -38,11 +38,11 @@ The SuperPlane CLI is the source of truth — discover exact names/IDs/schemas w
 3. **Confirm the secret** holding the droplet SSH key (`superplane secrets list`):
    - `STOREJS_SSH_DO`, key `private_key`
 4. **Find the prod droplet id:** `superplane integrations list-resources --id 505ed7fc-cc70-4226-8ff6-50e3ef601b8d --type droplet` → `storejs-prod` = `575470632`
-5. **Write the canvas YAML** (below), then create + lay out:
+5. **Apply the canvas YAML** in [.superplane/deploy-prod-on-main.yaml](deploy-prod-on-main.yaml), then create + lay out:
    ```bash
-   superplane apps create --canvas-file canvases/deploy-prod-on-main.yaml --canvas-auto-layout horizontal
+   superplane apps create --canvas-file .superplane/deploy-prod-on-main.yaml --canvas-auto-layout horizontal
    # later edits (file must include metadata.id; change management is disabled so no --draft needed):
-   superplane apps canvas update --file canvases/deploy-prod-on-main.yaml
+   superplane apps canvas update --file .superplane/deploy-prod-on-main.yaml
    ```
 6. **Verify clean:** `superplane apps canvas get storejs-deploy-on-main -o yaml` shows empty `errorMessage`/`warningMessage` on every node.
 7. **Validate a run** after a push to `main`:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # storejs
 
-Minimal Node.js CRUD demo for `Puppy` using Express + EJS.
+Minimal Node.js CRUD demo for `Cat` using Express + EJS.
 
 ## Local run
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,7 +22,7 @@ echo "Waiting for startup..."
 # Poll the health endpoint until the freshly restarted service responds.
 HTTP_STATUS=000
 for i in $(seq 1 30); do
-  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/puppies || true)
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/cats || true)
   [ "$HTTP_STATUS" = "200" ] && break
   sleep 2
 done

--- a/spec.md
+++ b/spec.md
@@ -2,13 +2,13 @@
 
 ## Goal
 
-Build a minimal demo web app in Node.js that shows a complete CRUD flow for a single entity: `Puppy`.
+Build a minimal demo web app in Node.js that shows a complete CRUD flow for a single entity: `Cat`.
 
 The app should be intentionally simple, readable, and easy to demo.
 
 ## Product Scope
 
-- Single domain entity: `Puppy`
+- Single domain entity: `Cat`
 - Single user-facing attribute: `name`
 - No additional business entities
 
@@ -24,19 +24,19 @@ The app should be intentionally simple, readable, and easy to demo.
 
 ### 1. Routing
 
-- `GET /` shows puppy index (homepage must be puppy management entry point)
-- Standard puppy CRUD routes:
-  - `GET /puppies`
-  - `GET /puppies/new`
-  - `POST /puppies`
-  - `GET /puppies/:id`
-  - `GET /puppies/:id/edit`
-  - `POST /puppies/:id` (or `PATCH/PUT` if framework supports method override cleanly)
-  - `POST /puppies/:id/delete` (or `DELETE` with method override)
+- `GET /` shows cat index (homepage must be cat management entry point)
+- Standard cat CRUD routes:
+  - `GET /cats`
+  - `GET /cats/new`
+  - `POST /cats`
+  - `GET /cats/:id`
+  - `GET /cats/:id/edit`
+  - `POST /cats/:id` (or `PATCH/PUT` if framework supports method override cleanly)
+  - `POST /cats/:id/delete` (or `DELETE` with method override)
 
 ### 2. Data Model
 
-`Puppy` fields:
+`Cat` fields:
 - `id` (primary key)
 - `name` (string)
 - timestamps if easy (`created_at`, `updated_at`)
@@ -47,46 +47,46 @@ Validation requirement:
 
 ### 3. HTML Pages
 
-#### Index (`/` and `/puppies`)
-- Heading: `Puppies`
-- List all puppies
-- For each puppy:
+#### Index (`/` and `/cats`)
+- Heading: `Cats`
+- List all cats
+- For each cat:
   - show `Name: <value>`
-  - show link to puppy detail page
-- Show `New puppy` action
+  - show link to cat detail page
+- Show `New cat` action
 
-#### New (`/puppies/new`)
-- Heading: `New puppy`
+#### New (`/cats/new`)
+- Heading: `New cat`
 - Form with:
   - label/input for `name`
   - submit action
-- Link back to puppies index
+- Link back to cats index
 
-#### Show (`/puppies/:id`)
-- Display puppy name
+#### Show (`/cats/:id`)
+- Display cat name
 - Actions:
   - edit
   - delete
   - back to index
 
-#### Edit (`/puppies/:id/edit`)
-- Heading: `Editing puppy`
+#### Edit (`/cats/:id/edit`)
+- Heading: `Editing cat`
 - Same form fields as New
 - Links to show page and index
 
 ### 4. CRUD Behavior
 
 - Create:
-  - saves puppy
-  - redirects to puppy show page
+  - saves cat
+  - redirects to cat show page
   - displays success notice
 - Update:
-  - updates puppy
-  - redirects to puppy show page
+  - updates cat
+  - redirects to cat show page
   - displays success notice
 - Delete:
-  - removes puppy
-  - redirects to puppies index
+  - removes cat
+  - redirects to cats index
   - displays success notice
 
 ### 5. UI Guidelines
@@ -97,7 +97,7 @@ Validation requirement:
 
 ### 6. Error Handling
 
-- If a puppy id does not exist, return a normal 404 page/response.
+- If a cat id does not exist, return a normal 404 page/response.
 - If form submission fails (if validations are introduced), re-render form with visible errors.
 
 ## Testing Requirements
@@ -105,17 +105,17 @@ Validation requirement:
 Implement basic automated tests for:
 - index page loads
 - new page loads
-- create increases puppy count and redirects correctly
+- create increases cat count and redirects correctly
 - show page loads
 - edit page loads
 - update persists change and redirects correctly
-- delete decreases puppy count and redirects correctly
+- delete decreases cat count and redirects correctly
 
 Keep tests fast and simple.
 
 ## Acceptance Criteria
 
-1. User can create, view, edit, and delete puppies via HTML pages.
-2. `/` resolves to puppies index.
+1. User can create, view, edit, and delete cats via HTML pages.
+2. `/` resolves to cats index.
 3. Success notices are shown after create/update/delete.
 4. UI remains intentionally minimal.

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const path = require('path');
-const { puppiesCreated, puppiesDeleted, puppiesTotal } = require('./metrics');
+const { catsCreated, catsDeleted, catsTotal } = require('./metrics');
 
 const app = express();
 
@@ -9,7 +9,7 @@ app.set('views', path.join(__dirname, 'views'));
 
 app.use(express.urlencoded({ extended: false }));
 
-let puppies = [];
+let cats = [];
 let nextId = 1;
 
 function setNotice(req, message) {
@@ -22,29 +22,29 @@ app.use((req, res, next) => {
   next();
 });
 
-function findPuppy(id) {
-  return puppies.find((puppy) => puppy.id === id);
+function findCat(id) {
+  return cats.find((cat) => cat.id === id);
 }
 
 app.get('/', (req, res) => {
-  res.redirect('/puppies');
+  res.redirect('/cats');
 });
 
-app.get('/puppies', (req, res) => {
-  res.render('puppies/index', { puppies });
+app.get('/cats', (req, res) => {
+  res.render('cats/index', { cats });
 });
 
 app.get('/about', (req, res) => {
   res.render('about');
 });
 
-app.get('/puppies/new', (req, res) => {
-  res.render('puppies/new', { puppy: { name: '' }, errors: [] });
+app.get('/cats/new', (req, res) => {
+  res.render('cats/new', { cat: { name: '' }, errors: [] });
 });
 
-app.post('/puppies', (req, res) => {
+app.post('/cats', (req, res) => {
   const now = new Date();
-  const puppy = {
+  const cat = {
     id: nextId,
     name: req.body.name || '',
     created_at: now,
@@ -52,48 +52,48 @@ app.post('/puppies', (req, res) => {
   };
 
   nextId += 1;
-  puppies.push(puppy);
-  puppiesCreated.add(1);
-  puppiesTotal.add(1);
+  cats.push(cat);
+  catsCreated.add(1);
+  catsTotal.add(1);
 
-  setNotice(req, 'Puppy was successfully created.');
-  res.redirect(`/puppies/${puppy.id}`);
+  setNotice(req, 'Cat was successfully created.');
+  res.redirect(`/cats/${cat.id}`);
 });
 
-app.get('/puppies/:id', (req, res, next) => {
-  const puppy = findPuppy(Number(req.params.id));
-  if (!puppy) return next();
-  res.render('puppies/show', { puppy });
+app.get('/cats/:id', (req, res, next) => {
+  const cat = findCat(Number(req.params.id));
+  if (!cat) return next();
+  res.render('cats/show', { cat });
 });
 
-app.get('/puppies/:id/edit', (req, res, next) => {
-  const puppy = findPuppy(Number(req.params.id));
-  if (!puppy) return next();
-  res.render('puppies/edit', { puppy, errors: [] });
+app.get('/cats/:id/edit', (req, res, next) => {
+  const cat = findCat(Number(req.params.id));
+  if (!cat) return next();
+  res.render('cats/edit', { cat, errors: [] });
 });
 
-app.post('/puppies/:id', (req, res, next) => {
-  const puppy = findPuppy(Number(req.params.id));
-  if (!puppy) return next();
+app.post('/cats/:id', (req, res, next) => {
+  const cat = findCat(Number(req.params.id));
+  if (!cat) return next();
 
-  puppy.name = req.body.name || '';
-  puppy.updated_at = new Date();
+  cat.name = req.body.name || '';
+  cat.updated_at = new Date();
 
-  setNotice(req, 'Puppy was successfully updated.');
-  res.redirect(`/puppies/${puppy.id}`);
+  setNotice(req, 'Cat was successfully updated.');
+  res.redirect(`/cats/${cat.id}`);
 });
 
-app.post('/puppies/:id/delete', (req, res, next) => {
+app.post('/cats/:id/delete', (req, res, next) => {
   const id = Number(req.params.id);
-  const puppy = findPuppy(id);
-  if (!puppy) return next();
+  const cat = findCat(id);
+  if (!cat) return next();
 
-  puppies = puppies.filter((item) => item.id !== id);
-  puppiesDeleted.add(1);
-  puppiesTotal.add(-1);
+  cats = cats.filter((item) => item.id !== id);
+  catsDeleted.add(1);
+  catsTotal.add(-1);
 
-  setNotice(req, 'Puppy was successfully deleted.');
-  res.redirect('/puppies');
+  setNotice(req, 'Cat was successfully deleted.');
+  res.redirect('/cats');
 });
 
 app.use((req, res) => {
@@ -101,7 +101,7 @@ app.use((req, res) => {
 });
 
 app.resetStore = () => {
-  puppies = [];
+  cats = [];
   nextId = 1;
   app.locals.notice = null;
 };

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -2,16 +2,16 @@ const { metrics } = require('@opentelemetry/api');
 
 const meter = metrics.getMeter('storejs-business');
 
-const puppiesCreated = meter.createCounter('store.puppies.created', {
-  description: 'Total number of puppies created',
+const catsCreated = meter.createCounter('store.cats.created', {
+  description: 'Total number of cats created',
 });
 
-const puppiesDeleted = meter.createCounter('store.puppies.deleted', {
-  description: 'Total number of puppies deleted',
+const catsDeleted = meter.createCounter('store.cats.deleted', {
+  description: 'Total number of cats deleted',
 });
 
-const puppiesTotal = meter.createUpDownCounter('store.puppies.total', {
-  description: 'Current number of puppies in the store',
+const catsTotal = meter.createUpDownCounter('store.cats.total', {
+  description: 'Current number of cats in the store',
 });
 
-module.exports = { puppiesCreated, puppiesDeleted, puppiesTotal };
+module.exports = { catsCreated, catsDeleted, catsTotal };

--- a/src/views/about.ejs
+++ b/src/views/about.ejs
@@ -23,16 +23,19 @@
  |_____/ \__\___/|_|  \___(_)_|_____/ 
     </pre>
 
-    <h2>About</h2>
-    <p>A demo store app built for testing preview environments with SuperPlane.</p>
+    <h2>🐱 About</h2>
+    <p>A demo cat store app built for testing preview environments with SuperPlane. 🐾</p>
+
+    <img src="https://cataas.com/cat" alt="A random cat" style="display:block; max-width: 300px; height: auto; border-radius: 8px; border: 1px solid #30363d; margin: 16px 0;" />
 
     <div class="stats">
       <p>🏗️ Runtime: <span>Node.js</span></p>
       <p>📦 Framework: <span>Express</span></p>
       <p>🛩️ Deployed via: <span>SuperPlane</span></p>
+      <p>🐈 Mascot: <span>Cats</span></p>
       <p>⏱️ Server time: <span><%= new Date().toISOString() %></span></p>
     </div>
 
-    <p><a href="/puppies">← Back to Puppies</a></p>
+    <p><a href="/cats">← Back to Cats 🐱</a></p>
   </body>
 </html>

--- a/src/views/cats/edit.ejs
+++ b/src/views/cats/edit.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StoreJS — New puppy</title>
+    <title>StoreJS — Editing cat</title>
     <style>
       body { background: #0d1117; color: #c9d1d9; font-family: "Segoe UI", system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
       h1 { color: #f0883e; border-bottom: 1px solid #30363d; padding-bottom: 8px; }
@@ -31,10 +31,10 @@
   </head>
   <body>
     <div class="nav">
-      <a href="/puppies" class="btn">← Puppies</a>
+      <a href="/cats/<%= cat.id %>" class="btn">← Back</a>
     </div>
 
-    <h1>New puppy</h1>
+    <h1>🐱 Editing cat</h1>
 
     <% if (errors && errors.length > 0) { %>
       <div class="error">
@@ -44,13 +44,13 @@
       </div>
     <% } %>
 
-    <form action="/puppies" method="post">
+    <form action="/cats/<%= cat.id %>" method="post">
       <p>
         <label for="name">Name</label>
-        <input id="name" name="name" type="text" value="<%= puppy.name %>" placeholder="Enter puppy name..." />
+        <input id="name" name="name" type="text" value="<%= cat.name %>" />
       </p>
       <p>
-        <button type="submit">Create Puppy</button>
+        <button type="submit">Update Cat 🐾</button>
       </p>
     </form>
   </body>

--- a/src/views/cats/index.ejs
+++ b/src/views/cats/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StoreJS — <%= puppy.name %></title>
+    <title>StoreJS — Cats</title>
     <style>
       body { background: #0d1117; color: #c9d1d9; font-family: "Segoe UI", system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
       h1 { color: #f0883e; border-bottom: 1px solid #30363d; padding-bottom: 8px; }
@@ -27,27 +27,35 @@
       .nav { margin-bottom: 24px; padding: 12px 0; border-bottom: 1px solid #30363d; }
       .nav a { margin-right: 16px; }
       form p { margin: 16px 0; }
+      .cat-photo { display: block; max-width: 100%; height: auto; border-radius: 8px; border: 1px solid #30363d; margin: 16px 0; }
     </style>
   </head>
   <body>
     <div class="nav">
-      <a href="/puppies" class="btn">← Puppies</a>
+      <a href="/cats" class="btn">🐱 Cats</a>
+      <a href="/cats/new" class="btn">+ New cat</a>
+      <a href="/about">About</a>
     </div>
 
     <% if (notice) { %>
       <div class="notice"><%= notice %></div>
     <% } %>
 
-    <h1><%= puppy.name %></h1>
+    <h1>🐱 Cats</h1>
 
-    <p>Name: <%= puppy.name %></p>
+    <img class="cat-photo" src="https://cataas.com/cat" alt="A random cat" />
 
-    <p>
-      <a href="/puppies/<%= puppy.id %>/edit" class="btn">Edit</a>
-    </p>
+    <% if (cats.length === 0) { %>
+      <p class="empty">No cats yet. Adopt your first feline friend! 🐾</p>
+    <% } %>
 
-    <form action="/puppies/<%= puppy.id %>/delete" method="post" style="margin-top: 24px;">
-      <button type="submit" class="btn-danger" style="background: #da3633; color: #fff; border: none; padding: 10px 20px; border-radius: 6px; cursor: pointer;">Delete</button>
-    </form>
+    <ul>
+      <% cats.forEach(function(cat) { %>
+        <li>
+          <span>😺 Name: <%= cat.name %></span>
+          <a href="/cats/<%= cat.id %>" class="btn">View →</a>
+        </li>
+      <% }) %>
+    </ul>
   </body>
 </html>

--- a/src/views/cats/new.ejs
+++ b/src/views/cats/new.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StoreJS — Puppies</title>
+    <title>StoreJS — New cat</title>
     <style>
       body { background: #0d1117; color: #c9d1d9; font-family: "Segoe UI", system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
       h1 { color: #f0883e; border-bottom: 1px solid #30363d; padding-bottom: 8px; }
@@ -31,28 +31,27 @@
   </head>
   <body>
     <div class="nav">
-      <a href="/puppies" class="btn">Puppies</a>
-      <a href="/puppies/new" class="btn">+ New puppy</a>
-      <a href="/about">About</a>
+      <a href="/cats" class="btn">← Cats</a>
     </div>
 
-    <% if (notice) { %>
-      <div class="notice"><%= notice %></div>
+    <h1>🐱 New cat</h1>
+
+    <% if (errors && errors.length > 0) { %>
+      <div class="error">
+        <% errors.forEach(function(error) { %>
+          <p><%= error %></p>
+        <% }) %>
+      </div>
     <% } %>
 
-    <h1>Puppies</h1>
-
-    <% if (puppies.length === 0) { %>
-      <p class="empty">No puppies yet. Adopt your first one!</p>
-    <% } %>
-
-    <ul>
-      <% puppies.forEach(function(puppy) { %>
-        <li>
-          <span>Name: <%= puppy.name %></span>
-          <a href="/puppies/<%= puppy.id %>" class="btn">View →</a>
-        </li>
-      <% }) %>
-    </ul>
+    <form action="/cats" method="post">
+      <p>
+        <label for="name">Name</label>
+        <input id="name" name="name" type="text" value="<%= cat.name %>" placeholder="Enter cat name..." />
+      </p>
+      <p>
+        <button type="submit">Create Cat 🐾</button>
+      </p>
+    </form>
   </body>
 </html>

--- a/src/views/cats/show.ejs
+++ b/src/views/cats/show.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StoreJS — Editing puppy</title>
+    <title>StoreJS — <%= cat.name %></title>
     <style>
       body { background: #0d1117; color: #c9d1d9; font-family: "Segoe UI", system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
       h1 { color: #f0883e; border-bottom: 1px solid #30363d; padding-bottom: 8px; }
@@ -27,31 +27,30 @@
       .nav { margin-bottom: 24px; padding: 12px 0; border-bottom: 1px solid #30363d; }
       .nav a { margin-right: 16px; }
       form p { margin: 16px 0; }
+      .cat-photo { display: block; max-width: 100%; height: auto; border-radius: 8px; border: 1px solid #30363d; margin: 16px 0; }
     </style>
   </head>
   <body>
     <div class="nav">
-      <a href="/puppies/<%= puppy.id %>" class="btn">← Back</a>
+      <a href="/cats" class="btn">← Cats</a>
     </div>
 
-    <h1>Editing puppy</h1>
-
-    <% if (errors && errors.length > 0) { %>
-      <div class="error">
-        <% errors.forEach(function(error) { %>
-          <p><%= error %></p>
-        <% }) %>
-      </div>
+    <% if (notice) { %>
+      <div class="notice"><%= notice %></div>
     <% } %>
 
-    <form action="/puppies/<%= puppy.id %>" method="post">
-      <p>
-        <label for="name">Name</label>
-        <input id="name" name="name" type="text" value="<%= puppy.name %>" />
-      </p>
-      <p>
-        <button type="submit">Update Puppy</button>
-      </p>
+    <h1>🐱 <%= cat.name %></h1>
+
+    <img class="cat-photo" src="https://cataas.com/cat?<%= cat.id %>" alt="A random cat" />
+
+    <p>😺 Name: <%= cat.name %></p>
+
+    <p>
+      <a href="/cats/<%= cat.id %>/edit" class="btn">Edit</a>
+    </p>
+
+    <form action="/cats/<%= cat.id %>/delete" method="post" style="margin-top: 24px;">
+      <button type="submit" class="btn-danger" style="background: #da3633; color: #fff; border: none; padding: 10px 20px; border-radius: 6px; cursor: pointer;">Delete</button>
     </form>
   </body>
 </html>

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,21 +1,21 @@
 const request = require('supertest');
 const app = require('../src/app');
 
-describe('Puppy CRUD', () => {
+describe('Cat CRUD', () => {
   beforeEach(() => {
     app.resetStore();
   });
 
   it('index page loads', async () => {
-    const response = await request(app).get('/puppies');
+    const response = await request(app).get('/cats');
     expect(response.status).toBe(200);
-    expect(response.text).toContain('Puppies');
+    expect(response.text).toContain('Cats');
   });
 
-  it('root redirects to puppies index', async () => {
+  it('root redirects to cats index', async () => {
     const response = await request(app).get('/');
     expect(response.status).toBe(302);
-    expect(response.headers.location).toBe('/puppies');
+    expect(response.headers.location).toBe('/cats');
   });
 
   it('about page loads', async () => {
@@ -25,74 +25,74 @@ describe('Puppy CRUD', () => {
   });
 
   it('new page loads', async () => {
-    const response = await request(app).get('/puppies/new');
+    const response = await request(app).get('/cats/new');
     expect(response.status).toBe(200);
-    expect(response.text).toContain('New puppy');
+    expect(response.text).toContain('New cat');
   });
 
-  it('create increases puppy count and redirects correctly', async () => {
+  it('create increases cat count and redirects correctly', async () => {
     const createResponse = await request(app)
-      .post('/puppies')
+      .post('/cats')
       .type('form')
-      .send({ name: 'Rex' });
+      .send({ name: 'Whiskers' });
 
     expect(createResponse.status).toBe(302);
-    expect(createResponse.headers.location).toBe('/puppies/1');
+    expect(createResponse.headers.location).toBe('/cats/1');
 
-    const showResponse = await request(app).get('/puppies/1');
-    expect(showResponse.text).toContain('Puppy was successfully created.');
+    const showResponse = await request(app).get('/cats/1');
+    expect(showResponse.text).toContain('Cat was successfully created.');
 
-    const indexResponse = await request(app).get('/puppies');
-    expect(indexResponse.text).toContain('Name: Rex');
+    const indexResponse = await request(app).get('/cats');
+    expect(indexResponse.text).toContain('Name: Whiskers');
   });
 
   it('show page loads', async () => {
-    await request(app).post('/puppies').type('form').send({ name: 'Buddy' });
+    await request(app).post('/cats').type('form').send({ name: 'Mittens' });
 
-    const response = await request(app).get('/puppies/1');
+    const response = await request(app).get('/cats/1');
     expect(response.status).toBe(200);
-    expect(response.text).toContain('Name: Buddy');
+    expect(response.text).toContain('Name: Mittens');
   });
 
   it('edit page loads', async () => {
-    await request(app).post('/puppies').type('form').send({ name: 'Daisy' });
+    await request(app).post('/cats').type('form').send({ name: 'Luna' });
 
-    const response = await request(app).get('/puppies/1/edit');
+    const response = await request(app).get('/cats/1/edit');
     expect(response.status).toBe(200);
-    expect(response.text).toContain('Editing puppy');
+    expect(response.text).toContain('Editing cat');
   });
 
   it('update persists change and redirects correctly', async () => {
-    await request(app).post('/puppies').type('form').send({ name: 'Old Name' });
+    await request(app).post('/cats').type('form').send({ name: 'Old Name' });
 
     const updateResponse = await request(app)
-      .post('/puppies/1')
+      .post('/cats/1')
       .type('form')
       .send({ name: 'New Name' });
 
     expect(updateResponse.status).toBe(302);
-    expect(updateResponse.headers.location).toBe('/puppies/1');
+    expect(updateResponse.headers.location).toBe('/cats/1');
 
-    const showResponse = await request(app).get('/puppies/1');
+    const showResponse = await request(app).get('/cats/1');
     expect(showResponse.text).toContain('Name: New Name');
-    expect(showResponse.text).toContain('Puppy was successfully updated.');
+    expect(showResponse.text).toContain('Cat was successfully updated.');
   });
 
-  it('delete decreases puppy count and redirects correctly', async () => {
-    await request(app).post('/puppies').type('form').send({ name: 'To Delete' });
+  it('delete decreases cat count and redirects correctly', async () => {
+    await request(app).post('/cats').type('form').send({ name: 'To Delete' });
 
-    const deleteResponse = await request(app).post('/puppies/1/delete');
+    const deleteResponse = await request(app).post('/cats/1/delete');
 
     expect(deleteResponse.status).toBe(302);
-    expect(deleteResponse.headers.location).toBe('/puppies');
+    expect(deleteResponse.headers.location).toBe('/cats');
 
-    const indexResponse = await request(app).get('/puppies');
+    const indexResponse = await request(app).get('/cats');
     expect(indexResponse.text).not.toContain('Name: To Delete');
-    expect(indexResponse.text).toContain('Puppy was successfully deleted.');
+    expect(indexResponse.text).toContain('Cat was successfully deleted.');
   });
 
-  it('returns 404 for missing puppy', async () => {
-    const response = await request(app).get('/puppies/999');
+  it('returns 404 for missing cat', async () => {
+    const response = await request(app).get('/cats/999');
     expect(response.status).toBe(404);
   });
 });


### PR DESCRIPTION
Rename routes, identifiers, OTel metrics (store.cats.*), views, tests, and docs from puppies to cats. Add cat emojis and a random cat photo from cataas.com in the UI. External infra identifiers (puppies-inc clone URLs, github-puppies SuperPlane resource) are left unchanged.